### PR TITLE
Fixed parameter name

### DIFF
--- a/window.h
+++ b/window.h
@@ -170,7 +170,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_CreateWindow, 0, 0, 6)
        ZEND_ARG_INFO(0, x)
        ZEND_ARG_INFO(0, y)
        ZEND_ARG_INFO(0, w)
-       ZEND_ARG_INFO(0, y)
+       ZEND_ARG_INFO(0, h)
        ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
I'm currently trying to generate some stub php files to ease auto-completion in my IDE, and I detected this variable misnamed (according to [original documentation](https://wiki.libsdl.org/SDL_CreateWindow) ).

Thank you for your awesome work for this extension (and for OpenGL one), it's really awesome to be able to play with graphical views in Php :+1: