### PR TITLE
feat: Support for SDL_RenderCopyEx

### DIFF
--- a/examples/007-mouse-events.php
+++ b/examples/007-mouse-events.php
@@ -20,6 +20,7 @@ SDL_FreeSurface($image);
 
 SDL_SetRenderDrawColor($renderer, 255, 0, 255, 255);
 
+$rotCenter = new SDL_Point(10, 10);
 $event = new SDL_Event;
 while (!$quit) {
 	while(SDL_PollEvent($event)) {
@@ -34,7 +35,7 @@ while (!$quit) {
             	$destRect->y = $event->motion->y;
             	$destRect->w = 64;//$drect->w;
             	$destRect->h = 64;//$drect->h;
-            	if (SDL_RenderCopy($renderer, $texture, NULL, $destRect) != 0) {
+            	if (SDL_RenderCopyEx($renderer, $texture, NULL, $destRect, 90, $rotCenter, SDL_FLIP_NONE) != 0) {
                 	echo SDL_GetError(), PHP_EOL;
             	}
             	SDL_RenderPresent($renderer);

--- a/php_sdl.c
+++ b/php_sdl.c
@@ -209,6 +209,7 @@ static zend_function_entry sdl_functions[] = {
 	ZEND_FE(SDL_RenderDrawPoint, arginfo_SDL_RenderDrawPoint)
 	ZEND_FE(SDL_RenderClear, arginfo_SDL_RenderClear)
 	ZEND_FE(SDL_RenderCopy, arginfo_SDL_RenderCopy)
+	ZEND_FE(SDL_RenderCopyEx, arginfo_SDL_RenderCopyEx)
 	ZEND_FE(SDL_RenderFillRect, arginfo_SDL_RenderFillRect)
 	ZEND_FE(SDL_RenderPresent, arginfo_SDL_RenderPresent)
 	ZEND_FE(SDL_CreateTextureFromSurface, arginfo_SDL_CreateTextureFromSurface)

--- a/render.c
+++ b/render.c
@@ -202,6 +202,42 @@ PHP_FUNCTION(SDL_RenderCopy)
 }
 /* }}} */
 
+PHP_FUNCTION(SDL_RenderCopyEx)
+{
+	zval *z_renderer, *z_texture;
+	zval *z_srcrect, *z_dstrect;
+	zval *z_center;
+	SDL_Renderer *renderer = NULL;
+	SDL_Texture *texture = NULL;
+	SDL_Rect *srcrect = NULL, *dstrect = NULL;
+	double angle;
+	SDL_Point *center = NULL;
+	long flip;
+
+	if( zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zzO!O!dO!l", &z_renderer, &z_texture, &z_srcrect, get_php_sdl_rect_ce(), &z_dstrect, get_php_sdl_rect_ce(), &angle, &z_center, get_php_sdl_point_ce(), &flip) == FAILURE ) {
+		WRONG_PARAM_COUNT;
+	}
+
+	renderer = (SDL_Renderer*)zend_fetch_resource(Z_RES_P(z_renderer), SDL_RENDERER_RES_NAME, le_sdl_renderer);
+	texture = (SDL_Texture*)zend_fetch_resource(Z_RES_P(z_texture), SDL_TEXTURE_RES_NAME, le_sdl_texture);
+
+	if(z_srcrect != NULL && Z_TYPE_P(z_srcrect) != IS_NULL) {
+		srcrect = (SDL_Rect*)emalloc(sizeof(SDL_Rect));
+		zval_to_sdl_rect(z_srcrect, srcrect TSRMLS_CC);
+	}
+	if(z_dstrect != NULL && Z_TYPE_P(z_dstrect) != IS_NULL) {
+		dstrect = (SDL_Rect*)ecalloc(1, sizeof(SDL_Rect));
+		zval_to_sdl_rect(z_dstrect, dstrect TSRMLS_CC);
+	}
+	if(z_center != NULL && Z_TYPE_P(z_center) != IS_NULL) {
+		center = (SDL_Point*)ecalloc(1, sizeof(SDL_Point));
+		zval_to_sdl_point(z_center, center TSRMLS_CC);
+	}
+
+	RETURN_LONG(SDL_RenderCopyEx(renderer, texture, srcrect, dstrect, angle, center, (Uint32)flip));
+}
+/* }}} */
+
 /* {{{ MINIT */
 PHP_MINIT_FUNCTION(sdl_render)
 {
@@ -209,6 +245,10 @@ PHP_MINIT_FUNCTION(sdl_render)
 	REGISTER_LONG_CONSTANT("SDL_RENDERER_ACCELERATED", SDL_RENDERER_ACCELERATED, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SDL_RENDERER_PRESENTVSYNC", SDL_RENDERER_PRESENTVSYNC, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SDL_RENDERER_TARGETTEXTURE", SDL_RENDERER_TARGETTEXTURE, CONST_CS | CONST_PERSISTENT);
+
+	REGISTER_LONG_CONSTANT("SDL_FLIP_NONE", SDL_FLIP_NONE, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("SDL_FLIP_HORIZONTAL", SDL_FLIP_HORIZONTAL, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("SDL_FLIP_VERTICAL", SDL_FLIP_VERTICAL, CONST_CS | CONST_PERSISTENT);
 
 	le_sdl_renderer = zend_register_list_destructors_ex(NULL, NULL, SDL_RENDERER_RES_NAME, module_number);
 	le_sdl_texture = zend_register_list_destructors_ex(NULL, NULL, SDL_TEXTURE_RES_NAME, module_number);

--- a/render.h
+++ b/render.h
@@ -85,6 +85,16 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_RenderCopy, 0, 0, 4)
 	ZEND_ARG_OBJ_INFO(0, dstrect, SDL_Rect, 1)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_RenderCopyEx, 0, 0, 7)
+	ZEND_ARG_INFO(0, renderer)
+	ZEND_ARG_INFO(0, texture)
+	ZEND_ARG_OBJ_INFO(0, srcrect, SDL_Rect, 1)
+	ZEND_ARG_OBJ_INFO(0, dstrect, SDL_Rect, 1)
+	ZEND_ARG_INFO(0, angle)
+	ZEND_ARG_OBJ_INFO(0, center, SDL_Point, 1)
+	ZEND_ARG_INFO(0, flip)
+ZEND_END_ARG_INFO()
+
 PHP_FUNCTION(SDL_SetRenderDrawColor);
 PHP_FUNCTION(SDL_RenderClear);
 PHP_FUNCTION(SDL_DestroyRenderer);
@@ -95,6 +105,7 @@ PHP_FUNCTION(SDL_RenderDrawPoint);
 PHP_FUNCTION(SDL_CreateTextureFromSurface);
 PHP_FUNCTION(SDL_CreateRenderer);
 PHP_FUNCTION(SDL_RenderCopy);
+PHP_FUNCTION(SDL_RenderCopyEx);
 
 PHP_MINIT_FUNCTION(sdl_render);
 


### PR DESCRIPTION
* Binded [`SDL_RenderCopyEx`](https://wiki.libsdl.org/SDL_RenderCopyEx) (mostly copied from `SDL_RenderCopy` code…)
* Added `SDL_FLIP_*` constants (needed as an argument for `SDL_RenderCopyEx`).
* Modified `007-mouse-events.php` example to test it, and demonstrate its usage.

Tell me if I have to improve something 😄 . 

I was not sure what to do about tests… Cannot determine if errors are due to my changes or not 😕 
Have a nice day!