### PR TITLE
Add texture and renderer functions

### DIFF
--- a/php_sdl.c
+++ b/php_sdl.c
@@ -213,6 +213,9 @@ static zend_function_entry sdl_functions[] = {
 	ZEND_FE(SDL_RenderFillRect, arginfo_SDL_RenderFillRect)
 	ZEND_FE(SDL_RenderPresent, arginfo_SDL_RenderPresent)
 	ZEND_FE(SDL_CreateTextureFromSurface, arginfo_SDL_CreateTextureFromSurface)
+	ZEND_FE(SDL_CreateTexture, arginfo_SDL_CreateTexture)
+	ZEND_FE(SDL_SetRenderTarget, arginfo_SDL_SetRenderTarget)
+	ZEND_FE(SDL_GetRendererOutputSize, arginfo_SDL_GetRendererOutputSize)
 
 	// Surface
 	ZEND_FE(SDL_CreateRGBSurface,			arginfo_SDL_CreateRGBSurface)

--- a/render.h
+++ b/render.h
@@ -72,6 +72,19 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_CreateTextureFromSurface, 0, 0, 2)
 	ZEND_ARG_OBJ_INFO(0, surface, SDL_Surface, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_CreateTexture, 0, 0, 5)
+	ZEND_ARG_INFO(0, renderer)
+	ZEND_ARG_INFO(0, format)
+	ZEND_ARG_INFO(0, access)
+	ZEND_ARG_INFO(0, w)
+	ZEND_ARG_INFO(0, h)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_SetRenderTarget, 0, 0, 2)
+	ZEND_ARG_INFO(0, renderer)
+	ZEND_ARG_INFO(0, texture)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_CreateRenderer, 0, 0, 3)
 	ZEND_ARG_OBJ_INFO(0, window, SDL_Window, 0)
 	ZEND_ARG_INFO(0, index)
@@ -95,6 +108,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_RenderCopyEx, 0, 0, 7)
 	ZEND_ARG_INFO(0, flip)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_GetRendererOutputSize, 0, 0, 3)
+	ZEND_ARG_INFO(0, renderer)
+	ZEND_ARG_INFO(1, w)
+	ZEND_ARG_INFO(1, h)
+ZEND_END_ARG_INFO()
+
 PHP_FUNCTION(SDL_SetRenderDrawColor);
 PHP_FUNCTION(SDL_RenderClear);
 PHP_FUNCTION(SDL_DestroyRenderer);
@@ -103,14 +122,17 @@ PHP_FUNCTION(SDL_RenderFillRect);
 PHP_FUNCTION(SDL_RenderPresent);
 PHP_FUNCTION(SDL_RenderDrawPoint);
 PHP_FUNCTION(SDL_CreateTextureFromSurface);
+PHP_FUNCTION(SDL_CreateTexture);
+PHP_FUNCTION(SDL_SetRenderTarget);
 PHP_FUNCTION(SDL_CreateRenderer);
 PHP_FUNCTION(SDL_RenderCopy);
 PHP_FUNCTION(SDL_RenderCopyEx);
+PHP_FUNCTION(SDL_GetRendererOutputSize);
 
 PHP_MINIT_FUNCTION(sdl_render);
 
 #ifdef  __cplusplus
-} // extern "C" 
+} // extern "C"
 #endif
 
 #endif /* PHP_SDL_RENDER_H */


### PR DESCRIPTION
This PR aims to add the following functions :
 * `SDL_CreateTexture`
 * `SDL_SetRenderTarget`
 * `SDL_GetRendererOutputSize`

The two first ones are working just fine.

:warning: But I struggle to get `SDL_GetRendererOutputSize()` working.
The C function call works, I was able to confirm that by using `php_printf("w: %d, h: %d\n", w, h);`.
I'm sure I'm missing something to get variables passed by reference but I don't know what.

I've spend a lot of hours on it and I'm still stuck, so any help would be very appreciated.