### PR TITLE
feat: Add SDL_RenderDrawRect function

### DIFF
--- a/examples/005-draw-rectangle.php
+++ b/examples/005-draw-rectangle.php
@@ -12,6 +12,10 @@ $rect = new SDL_Rect(50, 50, 50, 50);
 SDL_SetRenderDrawColor($renderer, 0, 0, 255, 255);
 SDL_RenderFillRect($renderer, $rect);
 
+$rect = new SDL_Rect(150, 150, 50, 50);
+SDL_SetRenderDrawColor($renderer, 0, 0, 0, 255);
+SDL_RenderDrawRect($renderer, $rect);
+
 SDL_RenderPresent($renderer);
 
 $iniTime = time();

--- a/php_sdl.c
+++ b/php_sdl.c
@@ -211,6 +211,7 @@ static zend_function_entry sdl_functions[] = {
 	ZEND_FE(SDL_RenderCopy, arginfo_SDL_RenderCopy)
 	ZEND_FE(SDL_RenderCopyEx, arginfo_SDL_RenderCopyEx)
 	ZEND_FE(SDL_RenderFillRect, arginfo_SDL_RenderFillRect)
+	ZEND_FE(SDL_RenderDrawRect, arginfo_SDL_RenderDrawRect)
 	ZEND_FE(SDL_RenderPresent, arginfo_SDL_RenderPresent)
 	ZEND_FE(SDL_CreateTextureFromSurface, arginfo_SDL_CreateTextureFromSurface)
 

--- a/render.c
+++ b/render.c
@@ -103,6 +103,24 @@ PHP_FUNCTION(SDL_RenderFillRect)
 	RETURN_LONG(SDL_RenderFillRect(renderer, &rect));
 }
 
+PHP_FUNCTION(SDL_RenderDrawRect)
+{
+	zval *z_renderer = NULL;
+	zval *z_rect = NULL;
+	SDL_Rect rect;
+	SDL_Renderer *renderer = NULL;
+
+	if( zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zO", &z_renderer, &z_rect, get_php_sdl_rect_ce()) == FAILURE ) {
+		WRONG_PARAM_COUNT;
+	}
+
+	zval_to_sdl_rect(z_rect, &rect TSRMLS_CC);
+
+	renderer = (SDL_Renderer*)zend_fetch_resource(Z_RES_P(z_renderer), SDL_RENDERER_RES_NAME, le_sdl_renderer);
+
+	RETURN_LONG(SDL_RenderDrawRect(renderer, &rect));
+}
+
 PHP_FUNCTION(SDL_RenderPresent)
 {
 	zval *z_renderer;

--- a/render.h
+++ b/render.h
@@ -56,6 +56,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_RenderFillRect, 0, 0, 2)
 	//ZEND_ARG_INFO(0, rect)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_RenderDrawRect, 0, 0, 2)
+	ZEND_ARG_INFO(0, renderer)
+	ZEND_ARG_OBJ_INFO(0, rect, SDL_Rect, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_RenderPresent, 0, 0, 1)
 	//ZEND_ARG_OBJ_INFO(0, renderer, SDL_Renderer, 0)
 	ZEND_ARG_INFO(0, renderer)
@@ -100,6 +105,7 @@ PHP_FUNCTION(SDL_RenderClear);
 PHP_FUNCTION(SDL_DestroyRenderer);
 PHP_FUNCTION(SDL_DestroyTexture);
 PHP_FUNCTION(SDL_RenderFillRect);
+PHP_FUNCTION(SDL_RenderDrawRect);
 PHP_FUNCTION(SDL_RenderPresent);
 PHP_FUNCTION(SDL_RenderDrawPoint);
 PHP_FUNCTION(SDL_CreateTextureFromSurface);


### PR DESCRIPTION
Adding support for [`SDL_RenderDrawRect`](https://wiki.libsdl.org/SDL_RenderDrawRect?highlight=(\bCategoryAPI\b)|(SDLFunctionTemplate)) function, by copying existing code for `SDL_RenderFillRect`.